### PR TITLE
Update version.yaml

### DIFF
--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,18 +1,14 @@
 1.0.1:
     - First version of Translate Extended
 1.0.2:
-    - Added backend settings page with option to opt-out from the browser lang detection and route prefixing
-    - Bug fixes
-    - Improved browser language matching
+    - Added backend settings page with option to opt-out from the browser lang detection and route prefixing. Bug fixed. Improved browser language matching
 1.0.3:
     - Fixed default plugin settings
 1.0.4:
     - Added extended locale picker
 1.0.5:
-    - Bug fixes
-    - Added setting for homepage redirect
+    - Bug fixes. Added setting for homepage redirect
 1.0.6:
-    - Support for translated page URLs
-    - Fix for switcher for pages in subdirectory of domain
+    - Support for translated page URLs. Fix for switcher for pages in subdirectory of domain
 1.0.7:
     - Specified 'web' middleware for Laravel 5.5 support


### PR DESCRIPTION
When update from console:
Excodus.TranslateExtended
- v1.0.1:  First version of Translate Extended
- **v1.0.2:  Migration file "Bug fixes" not found**
- **v1.0.2:  Migration file "Improved browser language matching" not found**
- v1.0.2:  Added backend settings page with option to opt-out from the browser lang detection and route prefixing
- v1.0.3:  Fixed default plugin settings
- v1.0.4:  Added extended locale picker
- **v1.0.5:  Migration file "Added setting for homepage redirect" not found**
- v1.0.5:  Bug fixes
- **v1.0.6:  Migration file "Fix for switcher for pages in subdirectory of domain" not found**
- v1.0.6:  Support for translated page URLs
- v1.0.7:  Specified 'web' middleware for Laravel 5.5 support