### PR TITLE
Add force_prefix option

### DIFF
--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -14,6 +14,8 @@ return [
         'prefer_user_session_comment'   => 'If enabled, language set in user session will have priority over preferred browser language. If disabled locale will be detected every time user re-enters the website.',
         'homepage_redirect'             => 'Homepage redirect',
         'homepage_redirect_comment'     => 'If enabled, locale shortcode will be added to homepage URL.',
+        'force_prefix'                  => 'Force language prefix',
+        'force_prefix_comment'          => 'If enabled, all GET requests for URLs without a shortcode will be prefixed with the locale shortcode',
         'localepicker_desc'             => 'Shows list of links to change front-end language.'
     ],
     'permissions' => [

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -23,3 +23,8 @@ fields:
     comment: excodus.translateextended::lang.strings.homepage_redirect_comment
     type: switch
     default: true
+  force_prefix:
+    label: excodus.translateextended::lang.strings.force_prefix
+    comment: excodus.translateextended::lang.strings.force_prefix_comment
+    type: switch
+    default: true

--- a/routes.php
+++ b/routes.php
@@ -83,6 +83,15 @@ App::before(function($request) {
             });
         }
 
+        if (Settings::get('force_prefix', true)) {
+            Route::get('/{any}', function ($any) use ($locale, $request) {
+                $redirect = $locale . '/' . $request->path();
+                if ($request->query()) {
+                    $redirect .= '?' . http_build_query($request->query());
+                }
+                return redirect($redirect);
+            })->where('any', '.*');
+        }
     }
 });
 

--- a/routes.php
+++ b/routes.php
@@ -84,8 +84,8 @@ App::before(function($request) {
         }
 
         if (Settings::get('force_prefix', true)) {
-            Route::get('/{any}', function ($any) use ($locale, $request) {
-                $redirect = $locale . '/' . $request->path();
+            Route::get('/{any}', function ($any) use ($translator, $request) {
+                $redirect = $translator->getDefaultLocale() . '/' . $request->path();
                 if ($request->query()) {
                     $redirect .= '?' . http_build_query($request->query());
                 }


### PR DESCRIPTION
This should allow forcing all URLs to be prefixed with the language shortcode (e.g. `/lollipop` currently has the same content as `/en/lollipop`, but with this `/lollipop` will be automatically redirected to the current locale). Solves #15.

There are a couple of things I am unsure about:

* I have this option enabled by default since I would imagine most people would want this enabled to prevent duplicate content. If you feel that this could somehow break things, I can set this to disabled so it would have to be manually enabled.
* Would it be better to always use the default locale from `$translator->getDefaultLocale()`, so `/{anything}` will always be redirected to `/{default_locale}/{anything}` or how I have it so that it will redirect to the locale based on the session or `HTTP_ACCEPT_LANGUAGE`? The reason I think always using the default locale might be a good idea is for consistency. For example, if someone links to `/about-us`, which for them gets redirected to `/en/about`, someone with a Spanish `HTTP_ACCEPT_LANGUAGE` might follow that link and then be redirected to `/es/about-us`, whereas the Spanish page might be `/es/acerca-de-nosotros`, therefore causing a 404.