### PR TITLE
Fix issues with session (fixes #17) and with redirect when TranslateExtended is loaded before Rainlab/Translate (fixes #18)

### DIFF
--- a/classes/BrowserMatching.php
+++ b/classes/BrowserMatching.php
@@ -1,0 +1,89 @@
+<?php namespace Excodus\TranslateExtended\Classes;
+
+/**
+ * Util functions for language detection from the client browser
+ */
+class BrowserMatching{
+
+    // browser language parser based on Gumbo's answer
+    // http://stackoverflow.com/a/3771447/3704886
+
+    // parse list of comma separated language tags and sort it by the quality value
+    public static function parseLanguageList($languageList) {
+        if (is_null($languageList)) {
+            if (!isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+                return array();
+            }
+            $languageList = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+        }
+        $languages = array();
+        $languageRanges = explode(',', trim($languageList));
+        foreach ($languageRanges as $languageRange) {
+            if (preg_match('/(\*|[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?/', trim($languageRange), $match)) {
+                if (!isset($match[2])) {
+                    $match[2] = '1.0';
+                } else {
+                    $match[2] = (string) floatval($match[2]);
+                }
+                if (!isset($languages[$match[2]])) {
+                    $languages[$match[2]] = strtolower($match[1]);
+                }
+            }
+        }
+        krsort($languages);
+        return $languages;
+    }
+
+    // compare two parsed arrays of language tags and find the matches
+    public static function findMatches($accepted, $available) {
+        $matches = array();
+        $any = false;
+        foreach ($available as $availableLocale => $availableName) {
+            foreach ($accepted as $acceptedQuality => $acceptedLocale) {
+            $acceptedQuality = floatval($acceptedQuality);
+            if ($acceptedQuality === 0.0) continue;
+                if ($acceptedLocale === '*') {
+                    $any = true;
+                }
+                $matchingGrade = self::matchLanguage($acceptedLocale, $availableLocale);
+                if ($matchingGrade > 0) {
+                    $q = ($acceptedQuality * $matchingGrade);
+                    if (!array_key_exists($availableLocale, $matches) || $matches[$availableLocale] < $q) {
+                        $matches[$availableLocale] = $q;
+                    }
+                }
+            }
+        }
+        if (count($matches) === 0 && $any) {
+            $matches = $available;
+        }
+        arsort($matches);
+        return $matches;
+    }
+
+
+    /**
+     * compare two language tags and distinguish the degree of matching
+     * edit: actually matching "en-us" with "en" will always return "1"
+     * @param $a [] user-accepted
+     * @param $b [] backend-available
+     * @return float|int
+     */
+    public static function matchLanguage($a, $b) {
+        // convert 'en-US' to 'en-us'
+        $b = strtolower($b);
+        $a = explode('-', $a);
+        $b = explode('-', $b);
+        $perfect_match = false;
+        for ($i=0, $n=min(count($a), count($b)); $i<$n; $i++) {
+            if ($a[$i] !== $b[$i]) break;
+            if (count($a) == count($b) && $i == $n-1) {
+                $perfect_match = true;
+            }
+        }
+
+        $val = $i === 0 ? 0 : (float) $i / count($a);
+        return $perfect_match ? 2 : $val;
+    }
+
+}

--- a/classes/ExtendedLocaleMiddleware.php
+++ b/classes/ExtendedLocaleMiddleware.php
@@ -29,11 +29,10 @@ class ExtendedLocaleMiddleware
         * TODO: hook the translate plugin's onSwitchLocale ajax handler instead of checking on post
         */
 
-        $locale = 
-            $this->localeFromPost() ?: 
-            $this->localeFromURL() ?:
-            $this->localeFromSession() ?:
-            $this->localeFromBrowser();
+        $this->localeFromPost() ?: 
+        $this->localeFromURL() ?:
+        $this->localeFromSession() ?:
+        $this->localeFromBrowser();
 
         return $next($request);
     }
@@ -46,6 +45,13 @@ class ExtendedLocaleMiddleware
 
     private function localeFromPost()
     {
+        if(!post('locale')){
+            return null;
+        }
+        
+        $translator = Translator::instance();
+        $translator->setLocale(post('locale'));
+
         return post('locale');
     }
 

--- a/classes/ExtendedLocaleMiddleware.php
+++ b/classes/ExtendedLocaleMiddleware.php
@@ -1,0 +1,83 @@
+<?php namespace Excodus\TranslateExtended\Classes;
+
+use RainLab\Translate\Classes\Translator;
+use Excodus\TranslateExtended\Classes\BrowserMatching;
+use Excodus\TranslateExtended\Models\Settings;
+use Closure;
+use Config;
+use Request;
+use RainLab\Translate\Models\Locale;
+
+/**
+ * Middleware for advanced locale detection
+ */
+class ExtendedLocaleMiddleware
+{
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        /*
+        * Behavior when changing locale from the locale picker; post('locale') has priority over locale in URL,
+        * because Request still have old locale in the URL, hence $locale is outdated and User sends new locale in the POST
+        * TODO: hook the translate plugin's onSwitchLocale ajax handler instead of checking on post
+        */
+
+        $locale = 
+            $this->localeFromPost() ?: 
+            $this->localeFromURL() ?:
+            $this->localeFromSession() ?:
+            $this->localeFromBrowser();
+
+        return $next($request);
+    }
+
+    private function localeFromURL()
+    {
+        $translator = Translator::instance();
+        return $translator->loadLocaleFromRequest() ? $translator->getLocale() : null;
+    }
+
+    private function localeFromPost()
+    {
+        return post('locale');
+    }
+
+    private function localeFromSession()
+    {
+        $translator = Translator::instance();
+        
+        return (Settings::get('prefer_user_session',true) && $translator->loadLocaleFromSession())
+            ? $translator->getLocale()
+            : null;
+    }
+
+    private function localeFromBrowser()
+    {
+        $translator = Translator::instance();
+
+        if(Settings::get('browser_language_detection',true) && isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])){
+            $accepted = BrowserMatching::parseLanguageList($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+            $available = Locale::listEnabled();
+            // match against languages enabled in Translate plugin
+            // TODO: allow october backend users to create their own mappings to the locale short codes
+            $matches = BrowserMatching::findMatches($accepted, $available);
+            // get the first match and save if not empty
+            if (!empty($matches)) {
+                $match = array_keys($matches)[0];
+                $translator->setLocale($match);
+                return $match;
+            }
+        }
+
+        return null;
+    }
+
+
+}

--- a/routes.php
+++ b/routes.php
@@ -7,8 +7,8 @@
  */
 
 use Excodus\TranslateExtended\Models\Settings;
+use Excodus\TranslateExtended\Classes\ExtendedLocaleMiddleware;
 use RainLab\Translate\Classes\Translator;
-use RainLab\Translate\Models\Locale;
 
 App::before(function($request) {
 
@@ -20,67 +20,28 @@ App::before(function($request) {
     if (!$translator->isConfigured())
         return;
 
-    $locale = Request::segment(1);
-    $localeSession = Session::get($translator::SESSION_LOCALE);
-
-    /*
-     * Behavior when changing locale from the locale picker; post('locale') has priority over $locale,
-     * because Request still have old locale in the URL, hence $locale is outdated and User sends new locale in the POST
-     * TODO: hook the translate plugin's onSwitchLocale ajax handler instead of checking on post
-     */
-    if (post('locale') && $locale != post('locale')) {
-        $translator->setLocale(post('locale'));
-    }
-
-    /*
-     * Behavior when there is no locale in the Request URL, first check in session and then try to match with default browser language
-     */
-    if (!$locale || !Locale::isValid($locale)) {
-        if (Settings::get('prefer_user_session',true) && $localeSession) {
-            $translator->setLocale($localeSession);
-        } else {
-            if(Settings::get('browser_language_detection',true) && isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-                // get the list of browser languages
-                $accepted = parseLanguageList($_SERVER['HTTP_ACCEPT_LANGUAGE']);
-                $available = Locale::listEnabled();
-                // match against languages enabled in Translate plugin
-                // TODO: allow october backend users to create their own mappings to the locale short codes
-                $matches = findMatches($accepted, $available);
-                // get the first match and save if not empty
-                if (!empty($matches)) {
-                    $match = array_keys($matches)[0];
-                    $translator->setLocale($match);
-                }
-            }
-        }
-    }
-
-    /*
-      * If it was unable to retrieve locale from session, route url or browser matching, just roll back to default locale
-    */
-    $locale = $translator->getLocale();
-
-    if (!Locale::isValid($locale)) {
-        $translator->setLocale($translator->getDefaultLocale());
-    }
-
+    $locale = $translator->loadLocaleFromRequest() ? $translator->getLocale() : null;
+    
     if(Settings::get('route_prefixing', true)) {
-        Route::group(['prefix' => $locale, 'middleware' => 'web'], function() {
-            Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
-        });
 
-        Route::any($locale, 'Cms\Classes\CmsController@run')->middleware('web');
-
-        Event::listen('cms.route', function() use ($locale) {
+        if($locale){
             Route::group(['prefix' => $locale, 'middleware' => 'web'], function() {
                 Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
             });
-        });
+
+            Route::any($locale, 'Cms\Classes\CmsController@run')->middleware('web');
+
+            Event::listen('cms.route', function() use ($locale) {
+                Route::group(['prefix' => $locale, 'middleware' => 'web'], function() {
+                    Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
+                });
+            });
+        }
 
         if(Settings::get('homepage_redirect', true)) {
-            Route::get('/', function() use ($locale) {
-                return redirect($locale);
-            });
+            Route::get('/', function() use($translator) {
+                return redirect($translator->getLocale());
+            })->middleware(['web', ExtendedLocaleMiddleware::class]);
         }
 
         if (Settings::get('force_prefix', true)) {
@@ -92,86 +53,7 @@ App::before(function($request) {
                 return redirect($redirect);
             })->where('any', '.*');
         }
+        
     }
 });
 
-// browser language parser based on Gumbo's answer
-// http://stackoverflow.com/a/3771447/3704886
-
-// parse list of comma separated language tags and sort it by the quality value
-function parseLanguageList($languageList) {
-    if (is_null($languageList)) {
-        if (!isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            return array();
-        }
-        $languageList = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-    }
-    $languages = array();
-    $languageRanges = explode(',', trim($languageList));
-    foreach ($languageRanges as $languageRange) {
-        if (preg_match('/(\*|[a-zA-Z0-9]{1,8}(?:-[a-zA-Z0-9]{1,8})*)(?:\s*;\s*q\s*=\s*(0(?:\.\d{0,3})|1(?:\.0{0,3})))?/', trim($languageRange), $match)) {
-            if (!isset($match[2])) {
-                $match[2] = '1.0';
-            } else {
-                $match[2] = (string) floatval($match[2]);
-            }
-            if (!isset($languages[$match[2]])) {
-                $languages[$match[2]] = strtolower($match[1]);
-            }
-        }
-    }
-    krsort($languages);
-    return $languages;
-}
-
-// compare two parsed arrays of language tags and find the matches
-function findMatches($accepted, $available) {
-    $matches = array();
-    $any = false;
-    foreach ($available as $availableLocale => $availableName) {
-        foreach ($accepted as $acceptedQuality => $acceptedLocale) {
-        $acceptedQuality = floatval($acceptedQuality);
-        if ($acceptedQuality === 0.0) continue;
-            if ($acceptedLocale === '*') {
-                $any = true;
-            }
-            $matchingGrade = matchLanguage($acceptedLocale, $availableLocale);
-            if ($matchingGrade > 0) {
-                $q = ($acceptedQuality * $matchingGrade);
-                if (!array_key_exists($availableLocale, $matches) || $matches[$availableLocale] < $q) {
-                    $matches[$availableLocale] = $q;
-                }
-            }
-        }
-    }
-    if (count($matches) === 0 && $any) {
-        $matches = $available;
-    }
-    arsort($matches);
-    return $matches;
-}
-
-
-/**
- * compare two language tags and distinguish the degree of matching
- * edit: actually matching "en-us" with "en" will always return "1"
- * @param $a [] user-accepted
- * @param $b [] backend-available
- * @return float|int
- */
-function matchLanguage($a, $b) {
-    // convert 'en-US' to 'en-us'
-    $b = strtolower($b);
-    $a = explode('-', $a);
-    $b = explode('-', $b);
-    $perfect_match = false;
-    for ($i=0, $n=min(count($a), count($b)); $i<$n; $i++) {
-        if ($a[$i] !== $b[$i]) break;
-        if (count($a) == count($b) && $i == $n-1) {
-            $perfect_match = true;
-        }
-    }
-
-    $val = $i === 0 ? 0 : (float) $i / count($a);
-    return $perfect_match ? 2 : $val;
-}


### PR DESCRIPTION
Many of the code has been moved to a middleware than is run after the StartSession middleware (in the "web" group) because Session cannot be accessed before routing (which was the cause of issue #17 )

#18 has been fixed with a call to `$translator->loadLocaleFromRequest()`in the new middleware.

Fixes #17 
Fixes #18 