### PR TITLE
October CMS 1.1.0 (Laravel 6) compatibility fix

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -26,14 +26,14 @@ App::before(function($request) {
 
         if($locale){
             Route::group(['prefix' => $locale, 'middleware' => 'web'], function() {
-                Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
+                Route::any('{slug?}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
             });
 
             Route::any($locale, 'Cms\Classes\CmsController@run')->middleware('web');
 
             Event::listen('cms.route', function() use ($locale) {
                 Route::group(['prefix' => $locale, 'middleware' => 'web'], function() {
-                    Route::any('{slug}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
+                    Route::any('{slug?}', 'Cms\Classes\CmsController@run')->where('slug', '(.*)?');
                 });
             });
         }


### PR DESCRIPTION
This changes the "slug" parameter in routes to be optional. This makes the plugin compatible with October CMS 1.1.0 and the Laravel 6 upgrade.

I would recommend, if you intend to merge this, that you release this fix as an "important" update to the plugin clearly stating that it requires the October CMS version above.